### PR TITLE
保存lrc的时候包含尾音结束时间

### DIFF
--- a/BetterLyrics.WinUI3/Helper/Lyrics/LyricsConverter.cs
+++ b/BetterLyrics.WinUI3/Helper/Lyrics/LyricsConverter.cs
@@ -41,6 +41,8 @@ namespace BetterLyrics.WinUI3.Helper.Lyrics
                             stringBuilder.Append(FormatToSyllableTimestamp(syllable.StartMs));
                             stringBuilder.Append(syllable.Text);
                         }
+                        var lastSyllable = line.PrimarySyllables[^1];
+                        stringBuilder.Append(FormatToSyllableTimestamp(lastSyllable.EndMs > lastSyllable.StartMs ? lastSyllable.EndMs : lastSyllable.StartMs + 500));
                     }
                     else
                     {


### PR DESCRIPTION
通过在行末加入时间戳简单修复 #291 ，无尾音长度数据是参考了下面ttml格式的处理方法（将起始时间加500ms作为结束时间）