### PR TITLE
保存lrc的时候包含尾音结束时间（若有）

### DIFF
--- a/BetterLyrics.WinUI3/Helper/Lyrics/LyricsConverter.cs
+++ b/BetterLyrics.WinUI3/Helper/Lyrics/LyricsConverter.cs
@@ -41,6 +41,8 @@ namespace BetterLyrics.WinUI3.Helper.Lyrics
                             stringBuilder.Append(FormatToSyllableTimestamp(syllable.StartMs));
                             stringBuilder.Append(syllable.Text);
                         }
+                        var lastSyllable = line.PrimarySyllables[^1];
+                        if(lastSyllable.EndMs > lastSyllable.StartMs) stringBuilder.Append(FormatToSyllableTimestamp(lastSyllable.EndMs));
                     }
                     else
                     {

--- a/BetterLyrics.WinUI3/Helper/Lyrics/LyricsConverter.cs
+++ b/BetterLyrics.WinUI3/Helper/Lyrics/LyricsConverter.cs
@@ -42,7 +42,7 @@ namespace BetterLyrics.WinUI3.Helper.Lyrics
                             stringBuilder.Append(syllable.Text);
                         }
                         var lastSyllable = line.PrimarySyllables[^1];
-                        if(lastSyllable.EndMs > lastSyllable.StartMs) stringBuilder.Append(FormatToSyllableTimestamp(lastSyllable.EndMs));
+                        if(lastSyllable.EndMs > lastSyllable.StartMs && lastSyllable.Text.Trim().Length > 0) stringBuilder.Append(FormatToSyllableTimestamp(lastSyllable.EndMs));
                     }
                     else
                     {


### PR DESCRIPTION
通过在行末加入时间戳简单修复 #291 ，无尾音长度数据则不添加

我实在是没能把项目跑起来，所以没有debug，应该不会有问题吧（？）
还是建议先测试一下有没有bug吧