### PR TITLE
feat: support Phone Link as a media source

### DIFF
--- a/src/BetterLyrics.DotNet/BetterLyrics.Core/Helpers/PlayerIdHelper.cs
+++ b/src/BetterLyrics.DotNet/BetterLyrics.Core/Helpers/PlayerIdHelper.cs
@@ -36,10 +36,15 @@ public static class PlayerIdHelper
     private static readonly List<string> _phoneLinkRegex =
     [
         "^Microsoft\\.YourPhone_",
+        "^Microsoft\\.YourPhone!",
         "^Microsoft\\.PhoneLink_",
+        "^Microsoft\\.PhoneLink!",
         "^Microsoft\\.CrossDeviceApp_",
+        "^Microsoft\\.CrossDeviceApp!",
+        "YourPhone\\.exe",
+        "PhoneLink\\.exe",
         "CrossDevice\\.exe",
-        "PhoneLink\\.exe"
+        "CrossDeviceResShell\\.exe"
     ];
 
     private static bool Is(string? id, List<string> regexes)
@@ -48,7 +53,7 @@ public static class PlayerIdHelper
 
         foreach (var regex in regexes)
         {
-            var isMatch = Regex.IsMatch(id, regex);
+            var isMatch = Regex.IsMatch(id, regex, RegexOptions.IgnoreCase);
             if (isMatch) return true;
         }
 

--- a/src/BetterLyrics.DotNet/BetterLyrics.Core/Helpers/PlayerIdHelper.cs
+++ b/src/BetterLyrics.DotNet/BetterLyrics.Core/Helpers/PlayerIdHelper.cs
@@ -33,6 +33,15 @@ public static class PlayerIdHelper
         "lx-music-desktop.exe"
     ];
 
+    private static readonly List<string> _phoneLinkRegex =
+    [
+        "^Microsoft\\.YourPhone_",
+        "^Microsoft\\.PhoneLink_",
+        "^Microsoft\\.CrossDeviceApp_",
+        "CrossDevice\\.exe",
+        "PhoneLink\\.exe"
+    ];
+
     private static bool Is(string? id, List<string> regexes)
     {
         if (id is null) return false;
@@ -59,6 +68,11 @@ public static class PlayerIdHelper
     public static bool IsLXMusic(string? id)
     {
         return Is(id, _lxMusicRegex);
+    }
+
+    public static bool IsPhoneLink(string? id)
+    {
+        return Is(id, _phoneLinkRegex);
     }
 
     public static bool IsAppleMusic(string? id)

--- a/src/BetterLyrics.DotNet/BetterLyrics.Core/Implementations/Services/GsmtcService/GsmtcService.cs
+++ b/src/BetterLyrics.DotNet/BetterLyrics.Core/Implementations/Services/GsmtcService/GsmtcService.cs
@@ -60,6 +60,9 @@ public partial class GsmtcService : BaseViewModel, IGsmtcService,
     private double _lxMusicPositionSeconds;
     private EventSourceReader? _lxMusicSse;
     private byte[]? _smtcAlbumArtBuffer;
+    private Timer? _phoneLinkPollingTimer;
+    private string? _lastPhoneLinkSongKey;
+    private int _isPhoneLinkPollingBusy;
 
     public GsmtcService(
         ISettingsService settingsService,
@@ -396,6 +399,7 @@ public partial class GsmtcService : BaseViewModel, IGsmtcService,
         if (firstTime || desiredSession != _currentDesiredSession)
         {
             _currentDesiredSession = desiredSession;
+            HandlePhoneLinkIfDetected(desiredSession?.SessionId);
             SendFocusedMessages();
         }
     }
@@ -531,6 +535,7 @@ public partial class GsmtcService : BaseViewModel, IGsmtcService,
             .Replace(ExtendedGenreFiled.FileName, "");
 
         HandleLXMusicIfDetected(sessionId);
+        HandlePhoneLinkIfDetected(sessionId);
 
         // 总是先停止 _memoryReader
         _memoryReader.Stop();
@@ -707,6 +712,87 @@ public partial class GsmtcService : BaseViewModel, IGsmtcService,
         {
             await Task.Delay(e.ReconnectDelay);
             if (_lxMusicSse != null && !_lxMusicSse.IsDisposed) _lxMusicSse.Start();
+        });
+    }
+
+    private void HandlePhoneLinkIfDetected(string? sessionId)
+    {
+        if (PlayerIdHelper.IsPhoneLink(sessionId) && _currentDesiredSession?.SessionId == sessionId)
+            StartPhoneLinkPolling();
+        else
+            StopPhoneLinkPolling();
+    }
+
+    private void StartPhoneLinkPolling()
+    {
+        if (_phoneLinkPollingTimer != null) return;
+
+        _logger.LogInformation("Phone Link 媒体源已检测到，启动轮询监听");
+        _lastPhoneLinkSongKey = null;
+        _phoneLinkPollingTimer = new Timer(PhoneLinkPollingTimer_Tick, null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+    }
+
+    private void StopPhoneLinkPolling()
+    {
+        if (_phoneLinkPollingTimer == null) return;
+
+        _phoneLinkPollingTimer.Dispose();
+        _phoneLinkPollingTimer = null;
+        _isPhoneLinkPollingBusy = 0;
+        _logger.LogInformation("Phone Link 轮询监听已停止");
+    }
+
+    private void PhoneLinkPollingTimer_Tick(object? state)
+    {
+        _appUIThreadProvider.Execute(async () =>
+        {
+            if (Interlocked.Exchange(ref _isPhoneLinkPollingBusy, 1) == 1) return;
+
+            try
+            {
+                var session = _currentDesiredSession;
+                if (session == null || !PlayerIdHelper.IsPhoneLink(session.SessionId))
+                {
+                    StopPhoneLinkPolling();
+                    return;
+                }
+
+                await session.TryRefreshMediaPropsAsync();
+                await session.TryRefreshTimelinePropsAsync();
+                await session.TryRefreshPlaybackStateAsync();
+
+                var songKey = $"{session.Title}|{session.Artist}";
+                if (songKey != _lastPhoneLinkSongKey)
+                {
+                    _lastPhoneLinkSongKey = songKey;
+                    await OnAnyMediaPropertyChangedCoreAsync(session);
+                }
+                else
+                {
+                    var isPlaying = session.PlaybackStatus == SessionPlaybackStatus.Playing;
+
+                    if (isPlaying)
+                        _scrobbleTimer.Change(0, 1000);
+                    else
+                        _scrobbleTimer.Change(Timeout.Infinite, Timeout.Infinite);
+
+                    if (IsMediaSourceTimelineSyncEnabled(session.SessionId))
+                        CurrentPosition = session.CurrentTime;
+
+                    CurrentSongInfo.DurationMs = session.EndTime.TotalMilliseconds;
+                    UpdateTargetScrobbledDuration();
+                    CurrentIsPlaying = isPlaying;
+                    _ = UpdateDiscordPresenceAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Phone Link 轮询监听异常");
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _isPhoneLinkPollingBusy, 0);
+            }
         });
     }
 

--- a/src/BetterLyrics.DotNet/BetterLyrics.Core/Models/Settings/MediaSourceProviderInfo.cs
+++ b/src/BetterLyrics.DotNet/BetterLyrics.Core/Models/Settings/MediaSourceProviderInfo.cs
@@ -30,6 +30,12 @@ public partial class MediaSourceProviderInfo : ObservableRecipient
             TimelineSyncThreshold = 1000;
             PositionOffset = 1000;
         }
+        else if (PlayerIdHelper.IsPhoneLink(provider))
+        {
+            // 存在一定延迟与抖动，因此使用更宽松的阈值避免频繁校准
+            TimelineSyncThreshold = 3000;
+            PositionOffset = 500;
+        }
         else
         {
             // 设置 300 以防不必要的重复同步
@@ -114,6 +120,7 @@ public partial class MediaSourceProviderInfo : ObservableRecipient
         [.. Enum.GetValues<AlbumArtSearchProvider>().Select(p => new AlbumArtSearchProviderInfo(p, true))];
 
     [JsonIgnore] public bool IsLXMusic => PlayerIdHelper.IsLXMusic(Provider);
+    [JsonIgnore] public bool IsPhoneLink => PlayerIdHelper.IsPhoneLink(Provider);
     [JsonIgnore] public bool IsBetterLyrics => PlayerIdHelper.IsBetterLyrics(Provider);
     [JsonIgnore] [ObservableProperty] public partial bool IsFocused { get; set; } = false;
 

--- a/src/BetterLyrics.DotNet/BetterLyrics.WinUI3/BetterLyrics.WinUI3/Controls/PlaybackSettingsControl.xaml
+++ b/src/BetterLyrics.DotNet/BetterLyrics.WinUI3/BetterLyrics.WinUI3/Controls/PlaybackSettingsControl.xaml
@@ -49,6 +49,11 @@
                         <HyperlinkButton x:Uid="PlaybackSettingsControlStopBetterLyricsPlayer" Command="{x:Bind ViewModel.StopTrackCommand}" />
                     </InfoBar.ActionButton>
                 </InfoBar>
+                <InfoBar
+                    x:Uid="PlaybackSettingsControlPhoneLinkDetected"
+                    IsClosable="False"
+                    IsOpen="{x:Bind ViewModel.GsmtcService.CurrentMediaSourceProviderInfo.IsPhoneLink, Mode=OneWay}"
+                    Severity="Informational" />
             </StackPanel>
 
             <!--  播放源列表  -->

--- a/src/BetterLyrics.DotNet/BetterLyrics.WinUI3/BetterLyrics.WinUI3/Providers/MediaManagerProvider.cs
+++ b/src/BetterLyrics.DotNet/BetterLyrics.WinUI3/BetterLyrics.WinUI3/Providers/MediaManagerProvider.cs
@@ -2,14 +2,24 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using WindowsMediaController;
 
 namespace BetterLyrics.WinUI3.Providers;
 
 public class MediaManagerProvider : IMediaManagerProvider
 {
+    private readonly IAppUIThreadProvider _appUIThreadProvider;
     private readonly MediaManager _mediaManager = new();
     private readonly ConcurrentDictionary<string, IMediaSessionProvider> _mediaSessions = new();
+    private readonly Timer _sessionSyncTimer;
+
+    public MediaManagerProvider(IAppUIThreadProvider appUiThreadProvider)
+    {
+        _appUIThreadProvider = appUiThreadProvider;
+        _sessionSyncTimer = new Timer(_ => _appUIThreadProvider.Execute(ForceUpdate), null, Timeout.Infinite,
+            Timeout.Infinite);
+    }
 
     public IMediaSessionProvider? FocusedSession
     {
@@ -43,6 +53,8 @@ public class MediaManagerProvider : IMediaManagerProvider
     public void Init()
     {
         _mediaManager.Start();
+
+        _sessionSyncTimer.Change(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
 
         _mediaManager.OnAnySessionOpened += MediaManager_OnAnySessionOpened;
         _mediaManager.OnAnySessionClosed += MediaManager_OnAnySessionClosed;

--- a/src/BetterLyrics.DotNet/BetterLyrics.WinUI3/BetterLyrics.WinUI3/Providers/MediaSessionProvider.cs
+++ b/src/BetterLyrics.DotNet/BetterLyrics.WinUI3/BetterLyrics.WinUI3/Providers/MediaSessionProvider.cs
@@ -40,18 +40,22 @@ public class MediaSessionProvider : IMediaSessionProvider
 
     public async Task TryRefreshMediaPropsAsync()
     {
-        try
+        for (var attempt = 0; attempt < 2; attempt++)
         {
-            var mediaProperties = await _session.ControlSession.TryGetMediaPropertiesAsync();
-            Title = mediaProperties.Title;
-            Artist = mediaProperties.Artist;
-            Album = mediaProperties.AlbumTitle;
+            try
+            {
+                var mediaProperties = await _session.ControlSession.TryGetMediaPropertiesAsync();
+                Title = mediaProperties.Title;
+                Artist = mediaProperties.Artist;
+                Album = mediaProperties.AlbumTitle;
 
-            Genres = mediaProperties.Genres.ToList();
-            Thumbnail = await mediaProperties.Thumbnail.ToByteArrayAsync();
-        }
-        catch (Exception)
-        {
+                Genres = mediaProperties.Genres.ToList();
+                Thumbnail = await mediaProperties.Thumbnail.ToByteArrayAsync();
+                return;
+            }
+            catch (Exception)
+            {
+            }
         }
     }
 

--- a/src/BetterLyrics.DotNet/BetterLyrics.WinUI3/BetterLyrics.WinUI3/Strings/en/Resources.resw
+++ b/src/BetterLyrics.DotNet/BetterLyrics.WinUI3/BetterLyrics.WinUI3/Strings/en/Resources.resw
@@ -1089,6 +1089,9 @@
   <data name="PlaybackSettingsControlBetterLyricsRunningInBackground.Message" xml:space="preserve">
     <value>BetterLyrics built-in player is still running in the background, and the software will ignore other playback sources. To listen to other playback sources, go to Music Gallery and click the stop button in the lower right corner</value>
   </data>
+  <data name="PlaybackSettingsControlPhoneLinkDetected.Message" xml:space="preserve">
+    <value>Windows Phone Link detected as the playback source. Phone media is synced via bridging, so a certain delay in lyrics and progress is expected</value>
+  </data>
   <data name="PlaybackSettingsControlMemoryReader.Description" xml:space="preserve">
     <value>Loads external configurations to read playback progress directly from target process memory. Please use with caution; the developer is not responsible for the safety of third-party configurations</value>
   </data>

--- a/src/BetterLyrics.DotNet/BetterLyrics.WinUI3/BetterLyrics.WinUI3/Strings/zh-Hans/Resources.resw
+++ b/src/BetterLyrics.DotNet/BetterLyrics.WinUI3/BetterLyrics.WinUI3/Strings/zh-Hans/Resources.resw
@@ -1089,6 +1089,9 @@
   <data name="PlaybackSettingsControlBetterLyricsRunningInBackground.Message" xml:space="preserve">
     <value>BetterLyrics 内置播放器仍在后台运行，软件将忽略其他播放源。要监听其他播放源，请进入 “音乐库” 并点击右下角的 “停止” 按钮</value>
   </data>
+  <data name="PlaybackSettingsControlPhoneLinkDetected.Message" xml:space="preserve">
+    <value>检测到 Windows 手机连接（Phone Link）作为播放源。手机媒体通过桥接同步，歌词与进度存在一定延迟属正常现象</value>
+  </data>
   <data name="PlaybackSettingsControlMemoryReader.Description" xml:space="preserve">
     <value>加载外部配置以直接从目标软件内存中读取播放进度。请谨慎使用，开发者不对第三方配置的安全性负责</value>
   </data>


### PR DESCRIPTION
添加了Windows手机连接为数据源的选项，可以在手机连接到Windows之后，侦测手机媒体播放然后同步歌词，适用于用手机播放音乐但是想要在Windows上查看歌词的。后台UI我没有添加，只是尝试实现了这个功能，然后因为gitignore的缘故缺少编译必要文件，所以烦请仓库作者测试该功能