### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.CN.md
+++ b/README.CN.md
@@ -170,11 +170,11 @@
 
 ## Star History
 
-<a href="https://www.star-history.com/jayfunc/betterlyrics#history">
+<a href="https://star-history.dera.page/#jayfunc/BetterLyrics&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=jayfunc/BetterLyrics&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=jayfunc/BetterLyrics&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=jayfunc/BetterLyrics&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=jayfunc/BetterLyrics&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=jayfunc/BetterLyrics&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=jayfunc/BetterLyrics&type=Date" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -168,11 +168,11 @@ If you like BetterLyrics, please consider supporting it. Your support helps keep
 
 ## ⭐ Star History
 
-<a href="https://www.star-history.com/jayfunc/betterlyrics#history">
+<a href="https://star-history.dera.page/#jayfunc/BetterLyrics&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=jayfunc/BetterLyrics&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=jayfunc/BetterLyrics&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=jayfunc/BetterLyrics&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=jayfunc/BetterLyrics&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=jayfunc/BetterLyrics&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=jayfunc/BetterLyrics&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The Star History chart in the READMEs is currently broken and shows nothing, which is a noticeable gap for visitors. This PR replaces the unserved chart endpoint with the working star-history.dera.page instance so the chart renders correctly again. The image sources and the chart links in README.md and README.CN.md have been updated accordingly.